### PR TITLE
Improper setting of Go-zero log level for Gorm

### DIFF
--- a/application/article/mq/etc/article.yaml
+++ b/application/article/mq/etc/article.yaml
@@ -2,7 +2,7 @@ Name: mq
 KqConsumerConf:
   Name: article-kq-consumer
   Brokers:
-    - 127.0.1:9092
+    - 127.0.0.1:9092
   Group: group-like-count
   Topic: topic-like-count
   Offset: last
@@ -11,7 +11,7 @@ KqConsumerConf:
 ArticleKqConsumerConf:
   Name: article-cache-kq-consumer
   Brokers:
-    - 127.0.1:9092
+    - 127.0.0.1:9092
   Group: group-article-event
   Topic: topic-article-event
   Offset: last

--- a/application/article/mq/internal/logic/articlelikenumlogic.go
+++ b/application/article/mq/internal/logic/articlelikenumlogic.go
@@ -31,7 +31,7 @@ func (l *ArticleLikeNumLogic) Consume(_, val string) error {
 	var msg *types.CanalLikeMsg
 	err := json.Unmarshal([]byte(val), &msg)
 	if err != nil {
-		logx.Errorf("Consume val: %s error: %v", val, err)
+		l.Logger.Errorf("Consume val: %s error: %v", val, err)
 		return err
 	}
 
@@ -49,12 +49,12 @@ func (l *ArticleLikeNumLogic) updateArticleLikeNum(ctx context.Context, msg *typ
 		}
 		id, err := strconv.ParseInt(d.ObjID, 10, 64)
 		if err != nil {
-			logx.Errorf("strconv.ParseInt id: %s error: %v", d.ID, err)
+			l.Logger.Errorf("strconv.ParseInt id: %s error: %v", d.ID, err)
 			continue
 		}
 		likeNum, err := strconv.ParseInt(d.LikeNum, 10, 64)
 		if err != nil {
-			logx.Errorf("strconv.ParseInt likeNum: %s error: %v", d.LikeNum, err)
+			l.Logger.Errorf("strconv.ParseInt likeNum: %s error: %v", d.LikeNum, err)
 			continue
 		}
 		err = l.svcCtx.ArticleModel.UpdateLikeNum(ctx, id, likeNum)

--- a/pkg/orm/orm.go
+++ b/pkg/orm/orm.go
@@ -31,23 +31,14 @@ func (l *ormLog) LogMode(level logger.LogLevel) logger.Interface {
 }
 
 func (l *ormLog) Info(ctx context.Context, format string, v ...interface{}) {
-	if l.LogLevel < logger.Info {
-		return
-	}
 	logx.WithContext(ctx).Infof(format, v...)
 }
 
 func (l *ormLog) Warn(ctx context.Context, fromat string, v ...interface{}) {
-	if l.LogLevel < logger.Warn {
-		return
-	}
 	logx.WithContext(ctx).Infof(fromat, v...)
 }
 
 func (l *ormLog) Error(ctx context.Context, format string, v ...interface{}) {
-	if l.LogLevel < logger.Error {
-		return
-	}
 	logx.WithContext(ctx).Errorf(format, v...)
 }
 


### PR DESCRIPTION
gorm中的LogLevel, Info的值为4, 在集成日志时使用的正是gorm中的LogLevel
此时输出日志判断参考gorm源码使用应使用 >= 
```go
// 以下代码取之gorm源码
const (
	// Silent silent log level
	Silent LogLevel = iota + 1
	// Error error log level
	Error
	// Warn warn log level
	Warn
	// Info info log level
	Info
)

// Info print info
func (l *logger) Info(ctx context.Context, msg string, data ...interface{}) {
	if l.LogLevel >= Info {
		l.Printf(l.infoStr+msg, append([]interface{}{utils.FileWithLineNum()}, data...)...)
	}
}
``` 

go-zero中的LogLevel, Info的值为1, 显然不能用同一套日志等级判断
```go
// 以下代码取之go-zero源码
const (
	// DebugLevel logs everything
	DebugLevel uint32 = iota
	// InfoLevel does not include debugs
	InfoLevel
	// ErrorLevel includes errors, slows, stacks
	ErrorLevel
	// SevereLevel only log severe messages
	SevereLevel
)
func shallLog(level uint32) bool {
	return atomic.LoadUint32(&logLevel) <= level
}
```
直接使用logx进行输出, logx会根据当前系统配置的日志等级输出日志
